### PR TITLE
Remove workbook calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,7 @@ How to use
 - Install the Torch CUDNN V4 library: `git clone https://github.com/soumith/cudnn.torch; cd cudnn; git co R4; luarocks make` This will give you `cudnn.SpatialBatchNormalization`, which helps save quite a lot of memory.
 - Download
   [CIFAR 10](http://torch7.s3-website-us-east-1.amazonaws.com/data/cifar-10-torch.tar.gz).
-  The code expects the files to be located in
-  `/mnt/cifar/data_batch_*.t7`
-- Comment out all the `workbook` calls. You should replace them with
-  your own reporting and model saving code.
+  Use `--dataRoot <cifar>` to specify the location of the extracted CIFAR 10 folder.
 - Run `train-cifar.lua`.
 
 CIFAR: Effect of model size

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ How to use
 - You need at least CUDA 7.0 and CuDNN v4.
 - Install Torch.
 - Install the Torch CUDNN V4 library: `git clone https://github.com/soumith/cudnn.torch; cd cudnn; git co R4; luarocks make` This will give you `cudnn.SpatialBatchNormalization`, which helps save quite a lot of memory.
+- Install nninit: `luarocks install nninit`.
 - Download
   [CIFAR 10](http://torch7.s3-website-us-east-1.amazonaws.com/data/cifar-10-torch.tar.gz).
   Use `--dataRoot <cifar>` to specify the location of the extracted CIFAR 10 folder.

--- a/residual-layers.lua
+++ b/residual-layers.lua
@@ -52,12 +52,16 @@ function addResidualLayer2(input,  nChannels, nOutChannels, stride)
    -- The first layer does the downsampling and the striding
    local net = cudnn.SpatialConvolution(nChannels, nOutChannels,
                                            3,3, stride,stride, 1,1)
-                                           :init('weight', nninit.kaiming, {gain = 'relu'})(input)
-   net = cudnn.SpatialBatchNormalization(nOutChannels)(net)
+                                           :init('weight', nninit.kaiming, {gain = 'relu'})
+                                           :init('bias', nninit.constant, 0)(input)
+   net = cudnn.SpatialBatchNormalization(nOutChannels)
+                                            :init('weight', nninit.normal, 1.0, 0.002)
+                                            :init('bias', nninit.constant, 0)(net)
    net = cudnn.ReLU(true)(net)
    net = cudnn.SpatialConvolution(nOutChannels, nOutChannels,
                                       3,3, 1,1, 1,1)
-                                      :init('weight', nninit.kaiming, {gain = 'relu'})(net)
+                                      :init('weight', nninit.kaiming, {gain = 'relu'})
+                                      :init('bias', nninit.constant, 0)(net)
    -- Should we put Batch Normalization here? I think not, because
    -- BN would force the output to have unit variance, which breaks the residual
    -- property of the network.

--- a/residual-layers.lua
+++ b/residual-layers.lua
@@ -22,6 +22,7 @@ require 'nn'
 require 'nngraph'
 require 'cudnn'
 require 'cunn'
+local nninit = require 'nninit'
 
 function addResidualLayer2(input,  nChannels, nOutChannels, stride)
    --[[
@@ -50,11 +51,13 @@ function addResidualLayer2(input,  nChannels, nOutChannels, stride)
    -- Path 1: Convolution
    -- The first layer does the downsampling and the striding
    local net = cudnn.SpatialConvolution(nChannels, nOutChannels,
-                                           3,3, stride,stride, 1,1)(input)
+                                           3,3, stride,stride, 1,1)
+                                           :init('weight', nninit.kaiming, {gain = 'relu'})(input)
    net = cudnn.SpatialBatchNormalization(nOutChannels)(net)
    net = cudnn.ReLU(true)(net)
    net = cudnn.SpatialConvolution(nOutChannels, nOutChannels,
-                                      3,3, 1,1, 1,1)(net)
+                                      3,3, 1,1, 1,1)
+                                      :init('weight', nninit.kaiming, {gain = 'relu'})(net)
    -- Should we put Batch Normalization here? I think not, because
    -- BN would force the output to have unit variance, which breaks the residual
    -- property of the network.

--- a/train-cifar.lua
+++ b/train-cifar.lua
@@ -28,12 +28,15 @@ require 'nngraph'
 require 'train-helpers'
 
 -- Feel free to comment these out.
-workbook = require'lab-workbook':newExperiment{}
-lossLog = workbook:newTimeSeriesLog("Training loss",
-                                    {"nImages", "loss"},
-                                    20)
-errorLog = workbook:newTimeSeriesLog("Testing Error",
-                                     {"nImages", "error"})
+hasWorkbook, labWorkbook = pcall(require, 'lab-workbook')
+if hasWorkbook then
+  workbook = labWorkbook:newExperiment{}
+  lossLog = workbook:newTimeSeriesLog("Training loss",
+                                      {"nImages", "loss"},
+                                      20)
+  errorLog = workbook:newTimeSeriesLog("Testing Error",
+                                       {"nImages", "error"})
+end
 
 opt = lapp[[
       --batchSize       (default 128)      Sub-batch size
@@ -205,7 +208,7 @@ function evalModel()
     local results = evaluateModel(model, dataTest)
     errorLog{nImages = sgdState.nSampledImages,
              error = 1.0 - results.correct1}
-    if (sgdState.epochCounter or -1) % 10 == 0 then
+    if hasWorkbook and (sgdState.epochCounter or -1) % 10 == 0 then
        workbook:saveTorch("model", model)
        workbook:saveTorch("sgdState", sgdState)
     end
@@ -233,8 +236,10 @@ exploreNcdu(model)
 --]]
 
 -- Begin saving the experiment to our workbook
-workbook:saveGitStatus()
-workbook:saveJSON("opt", opt)
+if hasWorkbook then
+  workbook:saveGitStatus()
+  workbook:saveJSON("opt", opt)
+end
 
 -- --[[
 TrainingHelpers.trainForever(

--- a/train-cifar.lua
+++ b/train-cifar.lua
@@ -197,8 +197,10 @@ function forwardBackwardBatch(batch)
     loss_val = loss_val / N
     gradients:mul( 1.0 / N )
 
-    lossLog{nImages = sgdState.nSampledImages,
-            loss = loss_val}
+    if hasWorkbook then
+      lossLog{nImages = sgdState.nSampledImages,
+              loss = loss_val}
+    end
 
     return loss_val, gradients, inputs:size(1) * N
 end
@@ -206,11 +208,13 @@ end
 
 function evalModel()
     local results = evaluateModel(model, dataTest)
-    errorLog{nImages = sgdState.nSampledImages,
-             error = 1.0 - results.correct1}
-    if hasWorkbook and (sgdState.epochCounter or -1) % 10 == 0 then
-       workbook:saveTorch("model", model)
-       workbook:saveTorch("sgdState", sgdState)
+    if hasWorkbook then
+      errorLog{nImages = sgdState.nSampledImages,
+               error = 1.0 - results.correct1}
+      if (sgdState.epochCounter or -1) % 10 == 0 then
+        workbook:saveTorch("model", model)
+        workbook:saveTorch("sgdState", sgdState)
+      end
     end
     if (sgdState.epochCounter or 0) > 300 then
         print("Training complete, go home")

--- a/train-cifar.lua
+++ b/train-cifar.lua
@@ -83,19 +83,6 @@ if opt.loadFrom == "" then
     model = nn.gModule({input}, {model})
     model:cuda()
     --print(#model:forward(torch.randn(100, 3, 32,32):cuda()))
-
-    model:apply(function(m)
-        -- Initialize weights
-        local name = torch.type(m)
-        if name:find('Convolution') then
-            m.weight:normal(0.0, math.sqrt(2/(m.nInputPlane*m.kW*m.kH)))
-            m.bias:fill(0)
-        elseif name:find('BatchNormalization') then
-            if m.weight then m.weight:normal(1.0, 0.002) end
-            if m.bias then m.bias:fill(0) end
-        end
-    end)
-
 else
     print("Loading model from "..opt.loadFrom)
     cutorch.setDevice(1)


### PR DESCRIPTION
Rather than having to comment out the workbook calls, I've wrapped them in if statements by using `pcall` to work out whether `'lab-workbook'` is available or not. Obviously I can't test if it is available, but now it can run without crashing.

I've also updated the docs to remove this and also mentioned `--dataRoot` because the docs make it sound like the data path is hardcoded in.
