### PR TITLE
Update residual-layers.lua to be consistent with other torch nn models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ snapshots
 mnist.hdf5
 *.swp
 cache
+*.bak

--- a/train-cifar.lua
+++ b/train-cifar.lua
@@ -71,13 +71,13 @@ if opt.loadFrom == "" then
     model = cudnn.SpatialBatchNormalization(16)(model)
     model = cudnn.ReLU(true)(model)
     ------> 16, 32,32   First Group
-    for i=1,N do   model = addResidualLayer2(model, 16)   end
+    for i=1,N do   model = ResidualLayer(16)(model)   end
     ------> 32, 16,16   Second Group
-    model = addResidualLayer2(model, 16, 32, 2)
-    for i=1,N-1 do   model = addResidualLayer2(model, 32)   end
+    model = ResidualLayer(16, 32, 2)(model)
+    for i=1,N-1 do   ResidualLayer(32)(model)   end
     ------> 64, 8,8     Third Group
-    model = addResidualLayer2(model, 32, 64, 2)
-    for i=1,N-1 do   model = addResidualLayer2(model, 64)   end
+    model = ResidualLayer(32, 64, 2)(model)
+    for i=1,N-1 do   model = ResidualLayer(64)(model)   end
     ------> 10, 8,8     Pooling, Linear, Softmax
     model = nn.SpatialAveragePooling(8,8)(model)
     model = nn.Reshape(64)(model)

--- a/train-cifar.lua
+++ b/train-cifar.lua
@@ -74,7 +74,7 @@ if opt.loadFrom == "" then
     for i=1,N do   model = ResidualLayer(16)(model)   end
     ------> 32, 16,16   Second Group
     model = ResidualLayer(16, 32, 2)(model)
-    for i=1,N-1 do   ResidualLayer(32)(model)   end
+    for i=1,N-1 do   model = ResidualLayer(32)(model)   end
     ------> 64, 8,8     Third Group
     model = ResidualLayer(32, 64, 2)(model)
     for i=1,N-1 do   model = ResidualLayer(64)(model)   end


### PR DESCRIPTION
Hi, 

I updated residual-layers.lua so that it can be used with other available layers in torch community. 

I thought this might be useful for someone who might want to use the residual layer in their network architecture.

This might be not the preferred way of @gcr. 

Anyway, thank you for sharing your review work. 

Best regards, 

Jaehyun

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gcr/torch-residual-networks/6)
<!-- Reviewable:end -->
