### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,10 @@ iterations on the above graph). Like their paper, we start at a
 learning rate of 0.1 and reduce it to 0.01 at 80 epochs and then to
 0.01 at 160 epochs.
 
-###Training loss
+### Training loss
 ![Training loss curve](http://i.imgur.com/XqKnNX1.png)
 
-###Testing error
+### Testing error
 ![Test error curve](http://i.imgur.com/lt2D5cA.png)
 
 | Model                                 | My Test Error | Reference Test Error from Tab. 6 | Artifacts |


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
